### PR TITLE
Add an -d option to specify output directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,13 +13,15 @@ const log = console.log;
 log(chalk.yellowBright("swagger-to-mock"));
 commander
   .arguments("<file>")
-  .action(async file => {
+  .option("-d, --dir <name>", "output directory")
+  .action(async (file, cmd) => {
     try {
       const content = parse(file);
       const responses = extractResponses(content);
       const schemas = extractSchemas(content);
       const composed = composeMockData(responses, schemas);
-      writeFiles(composed, log);
+      const outputPath = cmd.dir ? cmd.dir : ".";
+      writeFiles(composed, outputPath, log);
       log(chalk.yellowBright("Completed"));
     } catch (e) {
       log(chalk.redBright(e));

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,12 +21,13 @@ export const normalizePath = (path: string): string => {
 // Write each response to JSON files.
 export const writeFiles = (
   data: { [file: string]: any },
+  outputPath: string,
   log: (message: any) => void
 ): void => {
   Object.keys(data).forEach(key => {
     const val = data[key];
-    const fileName = `${key}.json`
-    const path = join(".", fileName);
+    const fileName = `${key}.json`;
+    const path = join(outputPath, fileName);
     log(fileName);
     const formatted = JSON.stringify(val, null, 2);
     fs.writeFileSync(path, formatted);


### PR DESCRIPTION
Add -d option into the command.
i.e ) `swagger-to-mock swagger.yaml -d tests/__mocks__`

Related to #7 