### PR TITLE
Fixed issue where array of object type would not generate nested data

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -112,6 +112,8 @@ export const parseArray = (
       return [schema];
     }
     return [];
+  } else if (isObject(arr.items)) {
+    return [parseObject(arr.items, schemas)];
   } else if (arr.items.type) {
     return [DataType.defaultValue(arr.items)];
   }


### PR DESCRIPTION
This change allows array's of custom defined objects to generate nested data instead of an empty array.