### PR TITLE
Added support for generating multiple examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 coverage
+.idea/

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "prebuild": "rm -rf ./dist/",
+    "start": "npm run build && node ./dist/index.js -d ./dist/",
     "prepublish": "npm run build",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,8 +1,8 @@
-import { ResponsesType, APPLICATION_JSON } from "./response";
-import { Schemas } from "./schema";
-import { normalizePath, getSchemaName } from "./util";
-import { REF, parseObject, parseArray } from "./parse";
-import { isObject, isArray } from "./dataType";
+import {APPLICATION_JSON, ResponsesType} from "./response";
+import {Schemas} from "./schema";
+import {getSchemaName, normalizeName, normalizePath} from "./util";
+import {parseArray, parseObject, REF} from "./parse";
+import {isArray, isObject} from "./dataType";
 
 type MockData = {
   [path: string]: any;
@@ -22,15 +22,21 @@ export const composeMockData = (
       if ("example" in val) {
         ret[pathKey] = val.example;
       } else if ("examples" in val) {
-        ret[pathKey] = val.examples;
+        if (Object.keys(val.examples).length <= 1) {
+          ret[pathKey] = val.examples;
+        } else {
+          for (let [key, example] of Object.entries<any>(val.examples)) {
+            const extendedPathKey = pathKey + "_" + normalizeName(key)
+            ret[extendedPathKey] = example["value"];
+          }
+        }
       } else if ("schema" in val) {
         const { schema } = val;
         const ref = schema[REF];
         if (ref) {
           const schemaName = getSchemaName(ref);
           if (schemaName) {
-            const values = schemas[schemaName];
-            ret[pathKey] = values;
+            ret[pathKey] = schemas[schemaName];
           }
         } else {
           if (isObject(schema)) {

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -1,8 +1,8 @@
-import {APPLICATION_JSON, ResponsesType} from "./response";
-import {Schemas} from "./schema";
-import {getSchemaName, normalizeName, normalizePath} from "./util";
-import {parseArray, parseObject, REF} from "./parse";
-import {isArray, isObject} from "./dataType";
+import { ResponsesType, APPLICATION_JSON } from "./response";
+import { Schemas } from "./schema";
+import { normalizeName, normalizePath, getSchemaName } from "./util";
+import { REF, parseObject, parseArray } from "./parse";
+import { isObject, isArray } from "./dataType";
 
 type MockData = {
   [path: string]: any;

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,6 +18,12 @@ export const normalizePath = (path: string): string => {
   return replaced.replace(/\//g, "_");
 };
 
+export const normalizeName = (name: string): string => {
+  return name.toLowerCase()
+      .replace(/ /g, "_")
+      .replace(/,/g, "");
+};
+
 // Write each response to JSON files.
 export const writeFiles = (
   data: { [file: string]: any },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "dist",
-    "target": "es5",
-    "lib": ["es2015"],
+    "target": "es2017",
+    "lib": ["es2017"],
     "declaration": true,
     "noImplicitAny": true,
     "inlineSourceMap": true,


### PR DESCRIPTION
This PR adds support for generating multiple named examples if a Swagger spec defines them.

**Ex:**
```yaml
paths:
  '/something':
    get:
      summary: Get Something
      operationId: getSomething
      responses:
        '200':
          content:
            application/json:
              schema:
                  $ref: ./myObject.yaml
              examples:
                Example One:
                  $ref: ./examples/one.yaml
                Example Two:
                  $ref: ./examples/two.yaml
```

This would now generate both `something_get_200_example_one.json` and `something_get_200_example_two.json`